### PR TITLE
Log when devices-api is needed to get token Id.

### DIFF
--- a/internal/dimovss/dimovss.go
+++ b/internal/dimovss/dimovss.go
@@ -73,10 +73,10 @@ func newVSSProcessor(lgr *service.Logger, devicesAPIGRPCAddr string) (*vssProces
 		return nil, fmt.Errorf("failed to dial devices api: %w", err)
 	}
 	deviceAPI := deviceapi.NewService(devicesConn)
-
+	limitedDeviceAPI := NewLimitedTokenGetter(deviceAPI, lgr)
 	return &vssProcessor{
 		logger:      lgr,
-		tokenGetter: deviceAPI,
+		tokenGetter: limitedDeviceAPI,
 	}, nil
 }
 

--- a/internal/dimovss/token_getter.go
+++ b/internal/dimovss/token_getter.go
@@ -1,0 +1,45 @@
+package dimovss
+
+import (
+	"context"
+	"time"
+
+	"github.com/DIMO-Network/model-garage/pkg/vss/convert"
+	"github.com/benthosdev/benthos/v4/public/service"
+	"golang.org/x/time/rate"
+)
+
+type LimitedTokenGetter struct {
+	tokenGetter convert.TokenIDGetter
+	limiters    map[string]*rate.Sometimes
+	logger      *service.Logger
+}
+
+func NewLimitedTokenGetter(tokenGetter convert.TokenIDGetter, logger *service.Logger) *LimitedTokenGetter {
+	return &LimitedTokenGetter{
+		tokenGetter: tokenGetter,
+		limiters:    map[string]*rate.Sometimes{},
+		logger:      logger,
+	}
+}
+
+// TokenIDFromSubject wraps a provided TokenIDGetter and logs successful queries once per day per userDevice.
+func (l *LimitedTokenGetter) TokenIDFromSubject(ctx context.Context, userDeviceID string) (uint32, error) {
+	tokenID, err := l.tokenGetter.TokenIDFromSubject(ctx, userDeviceID)
+	if err != nil {
+		return 0, err
+	}
+	limiter, ok := l.limiters[userDeviceID]
+	if !ok {
+		// limit to one log per day.
+		limiter = &rate.Sometimes{
+			Interval: time.Hour * 24,
+			First:    1,
+		}
+		l.limiters[userDeviceID] = limiter
+	}
+	limiter.Do(func() {
+		l.logger.Infof("Found token id '%d' for userDevice '%s'", tokenID, userDeviceID)
+	})
+	return tokenID, nil
+}


### PR DESCRIPTION
Adds rate-limited logging for successful devices-api queries. This relies on the knowledge that the conversion only uses the tokenGetter if the `vehilceTokenId` field does not exist.